### PR TITLE
use show_many_tickets endpoint if ticket ID given.

### DIFF
--- a/zdgrab/__init__.py
+++ b/zdgrab/__init__.py
@@ -68,7 +68,6 @@ def zdgrab(zd, agent='me', ticket_ids=None,
                              zd.zendesk_password))
 
     # Get the attachments from the given zendesk tickets
-    print('ticket_ids: {}'.format(ticket_ids))
     for ticket in response['results']:
         if ticket['result_type'] != 'ticket':
             # This is not actually a ticket. Weird. Skip it.

--- a/zdgrab/__init__.py
+++ b/zdgrab/__init__.py
@@ -38,7 +38,8 @@ def zdgrab(zd, agent='me', ticket_ids=None,
                         print "Query: {}".format(query) 
         #response = zd.search(query=query)
         res = zd.show_many_tickets(ids=query)
-        print('{}'.format(res))
+        if verbose:
+                        print('{}'.format(res))
         response = {}
         response['count'] = 0
         response['results'] = []

--- a/zdgrab/__init__.py
+++ b/zdgrab/__init__.py
@@ -33,7 +33,22 @@ def zdgrab(zd, agent='me', ticket_ids=None,
 
     if ticket_ids:
         # ticket_ids given, query for those
-        response = zd.search(query=' '.join(['ticket_id:' + s for s in map(str,ticket_ids)]))
+        query=','.join([s for s in map(str,ticket_ids)])
+        if verbose:
+                        print "Query: {}".format(query) 
+        #response = zd.search(query=query)
+        res = zd.show_many_tickets(ids=query)
+        print('{}'.format(res))
+        response = {}
+        response['count'] = 0
+        response['results'] = []
+        for resp in res['tickets']:
+            response['count'] += 1
+            resp['result_type'] = 'ticket'
+            response['results'].append(resp)
+            if verbose:
+                print('found: {}'.format(resp['id']))
+
     else:
         # List of tickets not given. Get all of the attachments for all of this
         # user's open tickets.
@@ -53,6 +68,7 @@ def zdgrab(zd, agent='me', ticket_ids=None,
                              zd.zendesk_password))
 
     # Get the attachments from the given zendesk tickets
+    print('ticket_ids: {}'.format(ticket_ids))
     for ticket in response['results']:
         if ticket['result_type'] != 'ticket':
             # This is not actually a ticket. Weird. Skip it.


### PR DESCRIPTION
ZenDesk doesn't support _searching_ on ticket ID.  If ticket ID(s) is/are provided on the command line, we should use the show_many_tickets endpoint to retrieve them without searching.
